### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 Lap timer running on a solar powered Raspberry Pi.
 
-[![Build Status](https://travis-ci.org/si618/pi-time.svg?branch=master)](https://travis-ci.org/si618/pi-time)&nbsp;[![Latest Version](https://img.shields.io/pypi/v/pi-time.svg Status](https://img.shields.io/pypi/status/pi-time.svg
+[![Build Status](https://travis-ci.org/si618/pi-time.svg?branch=master)](https://travis-ci.org/si618/pi-time)&nbsp;[![Latest Version](https://img.shields.io/pypi/v/pi-time.svg)](https://pypi.python.org/pypi/pi-time/)&nbsp;[![Development Status](https://img.shields.io/pypi/status/pi-time.svg)](https://pypi.python.org/pypi/pi-time/)
 
 #### Development Status
 

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 Lap timer running on a solar powered Raspberry Pi.
 
-[![Build Status](https://travis-ci.org/si618/pi-time.svg?branch=master)](https://travis-ci.org/si618/pi-time)&nbsp;[![Latest Version](https://pypip.in/version/pi-time/badge.svg)](https://pypi.python.org/pypi/pi-time/)&nbsp;[![Development Status](https://pypip.in/status/pi-time/badge.svg)](https://pypi.python.org/pypi/pi-time/)
+[![Build Status](https://travis-ci.org/si618/pi-time.svg?branch=master)](https://travis-ci.org/si618/pi-time)&nbsp;[![Latest Version](https://img.shields.io/pypi/v/pi-time.svg Status](https://img.shields.io/pypi/status/pi-time.svg
 
 #### Development Status
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20pi-time))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `pi-time`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.